### PR TITLE
lentis-common: make sshd a oneshot service

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -1247,6 +1247,7 @@ service sshd /system/bin/start-ssh
     priority -5
     user root
     group root
+    oneshot
     disabled
 
 # ro.build.type is currently broken on eng builds


### PR DESCRIPTION
sshd won't work in selinux enforcing mode, making it a oneshot
experience.

Change-Id: Ia0b192f7c84f0ee0632770deeea87660a6b0a868