### PR TITLE
lentis-common: make sshd a oneshot service

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -1251,11 +1251,8 @@ service sshd /system/bin/start-ssh
     priority -5
     user root
     group root
+    oneshot
     disabled
-
-# ro.build.type is currently broken on eng builds
-#on property:ro.build.type=eng
-#    start sshd
 
 on property:ro.build.flavor=lineage_kccat6-eng
     start sshd


### PR DESCRIPTION
sshd won't work in selinux enforcing mode, making it a oneshot
experience. Also remove ro.build.type trigger.

Change-Id: Ia0b192f7c84f0ee0632770deeea87660a6b0a868